### PR TITLE
blacklist: ignore all devices from VID 0x26a, no modems from 3D Robotics

### DIFF
--- a/src/77-mm-usb-device-blacklist.rules
+++ b/src/77-mm-usb-device-blacklist.rules
@@ -80,4 +80,7 @@ ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="fb00" ENV{ID_MM_DEVICE_IGNORE}="1"
 # All devices from the Swiss Federal Institute of Technology
 ATTRS{idVendor}=="0617", ENV{ID_MM_DEVICE_IGNORE}="1"
 
+# All devices from 3D Robotics
+ATTRS{idVendor}=="26ac", ENV{ID_MM_DEVICE_IGNORE}="1"
+
 LABEL="mm_usb_device_blacklist_end"


### PR DESCRIPTION
The autopilots sold by [3D Robotics](http://3drobotics.com) show up as /dev/ttyACMx. When they are automatically probed by the ModemManager, the firmware upload tends to fail.

I therefore recommend to include this VendorId. Thanks.
