### PR TITLE
Update 77-mm-usb-device-blacklist.rules

### DIFF
--- a/src/77-mm-usb-device-blacklist.rules
+++ b/src/77-mm-usb-device-blacklist.rules
@@ -80,4 +80,7 @@ ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="fb00" ENV{ID_MM_DEVICE_IGNORE}="1"
 # All devices from the Swiss Federal Institute of Technology
 ATTRS{idVendor}=="0617", ENV{ID_MM_DEVICE_IGNORE}="1"
 
+# All devices from the Access Interfacing Solutions
+ATTRS{idVendor}=="0DB5", ENV{ID_MM_DEVICE_IGNORE}="1"
+
 LABEL="mm_usb_device_blacklist_end"


### PR DESCRIPTION
Black list all devices from Access IS - http://www.access-is.com
We do not produce modems and never will, but the majority of our devices have a CDC configuration option that MM incorrectly interprets as modems.
